### PR TITLE
Disable default features for arrayvec dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 extended_eci = ["encoding_rs"]
 
 [dependencies]
-arrayvec = "0.7"
+arrayvec = { version = "0.7", default-features = false }
 flagset = "0.4"
 encoding_rs = { version = "0.8", optional = true }
 


### PR DESCRIPTION
The arrayvec dependency enables its feature 'std' by default and therefor pulls in std by default. This makes building this crate in a no_std environment fail.

There is apparently nothing a dependent of this crate could do about it. Features are resolved among the entire dependency tree. But we can disable 'std' for arrayvec and leave it to others to turn it on.

See
https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2 for more hints.